### PR TITLE
fix: handle empty string event names

### DIFF
--- a/src/eventified.ts
+++ b/src/eventified.ts
@@ -268,11 +268,11 @@ export class Eventified implements IEventEmitter {
 	 * @returns {number} The number of listeners
 	 */
 	public listenerCount(eventName?: string | symbol): number {
-		if (!eventName) {
+		if (eventName === undefined) {
 			return this.getAllListeners().length;
 		}
 
-		const listeners = this._eventListeners.get(eventName as string);
+		const listeners = this._eventListeners.get(eventName);
 		return listeners ? listeners.length : 0;
 	}
 
@@ -290,7 +290,7 @@ export class Eventified implements IEventEmitter {
 	 * @returns {EventListener[]} An array of listeners
 	 */
 	public rawListeners(event?: string | symbol): EventListener[] {
-		if (!event) {
+		if (event === undefined) {
 			return this.getAllListeners();
 		}
 
@@ -447,7 +447,7 @@ export class Eventified implements IEventEmitter {
 	 * @param {string} [event] (Optional) The event name
 	 * @returns {EventListener[]} An array of listeners
 	 */
-	public listeners(event: string): EventListener[] {
+	public listeners(event: string | symbol): EventListener[] {
 		return this._eventListeners.get(event) ?? [];
 	}
 
@@ -456,8 +456,8 @@ export class Eventified implements IEventEmitter {
 	 * @param {string} [event] (Optional) The event name
 	 * @returns {IEventEmitter} returns the instance of the class for chaining
 	 */
-	public removeAllListeners(event?: string): IEventEmitter {
-		if (event) {
+	public removeAllListeners(event?: string | symbol): IEventEmitter {
+		if (event !== undefined) {
 			this._eventListeners.delete(event);
 		} else {
 			this._eventListeners.clear();

--- a/test/eventified.test.ts
+++ b/test/eventified.test.ts
@@ -190,6 +190,21 @@ describe("Eventified", () => {
 		t.expect(emitter.listenerCount("test-event")).toBe(0);
 	});
 
+	test("handles empty string event names", (t) => {
+		const emitter = new Eventified();
+		const listener = () => {};
+
+		emitter.on("", listener);
+		emitter.on("other", listener);
+
+		t.expect(emitter.listenerCount("")).toBe(1);
+		t.expect(emitter.rawListeners("")).toEqual([listener]);
+
+		emitter.removeAllListeners("");
+		t.expect(emitter.listenerCount("")).toBe(0);
+		t.expect(emitter.listenerCount("other")).toBe(1);
+	});
+
 	test("get event names", (t) => {
 		const emitter = new Eventified();
 		const listener = () => {};


### PR DESCRIPTION
## Summary
- ensure Eventified distinguishes empty-string event names from missing events
- test listenerCount, rawListeners, and removeAllListeners with empty event names

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb9177e488324b09603266b4e7c2c