### PR TITLE
release: v3.0.0 (breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 # Table of Contents
 - [Installation](#installation)
 - [Usage](#usage)
+- [Migrating from v2 to v3](#migrating-from-v2-to-v3)
 - [Migrating from v1 to v2](#migrating-from-v1-to-v2)
 - [Using it in the Browser](#using-it-in-the-browser)
 - [Hooks](#hooks)
@@ -1362,6 +1363,22 @@ This shows how on par `hookified` is to the native `EventEmitter` and popular `e
 |  Emittery (v2.0.0)        |   -92%    |       1M  |    792ns  |  ±0.01%  |       1M  |
 
 _Note: the `EventEmitter` version is Nodejs versioning._
+
+# Migrating from v2 to v3
+
+v3 has no API changes. The only breaking change is the minimum Node.js version requirement.
+
+## Breaking Changes
+
+| Change | Summary |
+|---|---|
+| Node.js version | Minimum required version is now `>=22.18.0` (previously no `engines` constraint) |
+
+### Node.js >=22.18.0 required
+
+The `engines` field in `package.json` now requires Node.js 22.18.0 or later. Node.js 20 reached end-of-life in April 2026.
+
+**Migration:** Upgrade to Node.js 22 LTS or Node.js 24+. No code changes are required — the library API is identical to v2.
 
 # Migrating from v1 to v2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hookified",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Event Emitting and Middleware Hooks",
   "type": "module",
   "main": "./dist/node/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hookified",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Event Emitting and Middleware Hooks",
   "type": "module",
   "main": "./dist/node/index.js",


### PR DESCRIPTION
## Release summary
Major release: drops Node 20 support via engines.node >=22.18.0, upgrades all devDependencies and CI workflows.

## hookified@3.0.0 — 2026-05-24

Major release dropping Node 20 support and upgrading all devDependencies and CI workflows.

### ⚠ BREAKING CHANGES
- Node.js >=22.18.0 is now required via the `engines` field in package.json (1f19313, #159)
  Migration: upgrade to Node 22 LTS or Node 24+.

### Internal
- upgrade code quality dependencies (38713d4, #158)
- add allowBuilds for esbuild/unrs-resolver (74fe3d0, #158)
- upgrade codeql workflow actions (bbd6f7d, #158)
- upgrade TypeScript and build tooling (4912fdb, #159)
- upgrade GitHub Actions (93fb7ff, #160)
- upgrade docula (735a0e3, #161)

### Full List of Changes
- root - chore: upgrade code quality dependencies by @jaredwray in #158
- root - chore: upgrade TypeScript and build tooling by @jaredwray in #159
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #160
- root - chore: upgrade docula (breaking) by @jaredwray in #161

### Contributors
- @jaredwray (7)

**Full diff:** https://github.com/jaredwray/hookified/compare/570f6b6...release/v2.3.0

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes locally (300/300, 100% coverage)
- [x] No uncommitted changes outside the version bump

## Post-merge
Merge the PR, then create a GitHub Release at tag `v3.0.0` — the `release.yaml` workflow publishes to npm.
