### PR TITLE
fix: allow sharp and workerd build scripts for wrangler

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,11 @@
 allowBuilds:
   esbuild: true
+  sharp: true
   unrs-resolver: true
+  workerd: true
 minimumReleaseAge: 2880
 onlyBuiltDependencies:
   - esbuild
+  - sharp
   - unrs-resolver
+  - workerd


### PR DESCRIPTION
## Summary

- The `deploy-site` workflow uses `cloudflare/wrangler-action@v4`, which installs wrangler via pnpm
- Wrangler depends on `sharp` and `workerd`, both of which need to run post-install build scripts
- These packages were not in the `onlyBuiltDependencies` allowlist in `pnpm-workspace.yaml`, causing pnpm to fail with `ERR_PNPM_IGNORED_BUILDS`
- Added `sharp` and `workerd` to both `allowBuilds` and `onlyBuiltDependencies` to fix the CI failure

## Test plan

- [ ] Re-run the `deploy-site` workflow and verify the "Publish to Cloudflare Pages" step no longer fails with `ERR_PNPM_IGNORED_BUILDS`

https://claude.ai/code/session_017wBmWmiYeXWkSM7A1pkDAN

---
_Generated by [Claude Code](https://claude.ai/code/session_017wBmWmiYeXWkSM7A1pkDAN)_