### PR TITLE
ci: use npm provenance with OIDC for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
@@ -23,7 +25,7 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
 
     - name: Build
       run: pnpm build
@@ -32,7 +34,5 @@ jobs:
       run: pnpm test
 
     - name: Publish
-      run: npm publish --provenance --access public --ignore-scripts
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: pnpm publish --provenance --access public --no-git-checks
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,8 @@ on:
     types: [released]
 
 permissions:
-  contents: read    
+  contents: read
+  id-token: write
 
 jobs:
   build:
@@ -19,20 +20,19 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: 24
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install Dependencies
       run: npm install pnpm -g && pnpm install
 
-    - name: Build    
+    - name: Build
       run: pnpm build
 
-    - name: Testing    
+    - name: Testing
       run: pnpm test
 
     - name: Publish
-      run: |
-        npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-        npm publish --ignore-scripts
+      run: npm publish --provenance --access public --ignore-scripts
       env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Added `id-token: write` permission to enable OIDC-based authentication for npm provenance
- Configured `registry-url` in `setup-node` so `NODE_AUTH_TOKEN` is picked up automatically
- Changed publish command to use `--provenance --access public` for supply chain attestation
- Replaced manual `npm config set` auth with `NODE_AUTH_TOKEN` env var (the standard approach when using `setup-node` with `registry-url`)

## Test plan

- [ ] Verify the release workflow YAML is valid
- [ ] Trigger a test release to confirm OIDC token exchange works with npm
- [ ] Confirm published package shows provenance badge on npmjs.com

https://claude.ai/code/session_017J5g11QjfGTdRWzY8NUJBs

---
_Generated by [Claude Code](https://claude.ai/code/session_017J5g11QjfGTdRWzY8NUJBs)_