### PR TITLE
Remove Node.js version requirement from features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 # Features
 - Simple replacement for EventEmitter
 - Async / Sync Middleware Hooks for Your Methods 
-- ESM / CJS with Types and Nodejs 20+
+- ESM / CJS with Types
 - Browser Support and Delivered via CDN
 - Ability to throw errors in hooks
 - Ability to pass in a logger (such as Pino) for errors


### PR DESCRIPTION
## Summary
- Removes "and Nodejs 20+" from the ESM/CJS features bullet in the README

## Test plan
- [x] Verify README renders correctly

https://claude.ai/code/session_018S4HJX31pKTZYCPZKfNnse

---
_Generated by [Claude Code](https://claude.ai/code/session_018S4HJX31pKTZYCPZKfNnse)_