### PR TITLE
release: v3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hookified",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Event Emitting and Middleware Hooks",
   "type": "module",
   "main": "./dist/node/index.js",


### PR DESCRIPTION
## Release summary
Patch release fixing once-listener/hook removal-by-original-reference leaks and emit mid-mutation safety.

## hookified@3.0.1 — 2026-06-22

Patch release fixing once-listener/hook removal-by-original-reference leaks and emit mid-mutation safety.

### Bug Fixes
- remove once listeners/hooks when called with the original reference (45a81bc, #168)
- guard once-wrapper matching against undefined targets (7f0a45e, #168)
- prefer exact reference match over once-wrapper when removing (c0ca435, #168)
- iterate a snapshot of listeners in emit to survive mid-emit mutation (2c4c622, #168)

### Documentation
- remove Node.js version requirement from features list (e14c890, #166)

### Internal
- migrate to corepack with pnpm 11 and defense-in-depth supply chain controls (ebd7888, #167)
- upgrade docula to 2.0.0 with minimumReleaseAgeExclude (804fd47, #167)
- upgrade code quality dependencies (fb05569, #169)
- upgrade TypeScript and build tooling (0b3b035, #170)
- upgrade GitHub Actions (8545caa, #171)
- add multi-listener emit benchmark (0772629, #168)
- use npm provenance with OIDC for release workflow (815c447, #165)
- address review feedback on release workflow (7b5897d, #165)
- add Cloudflare account ID to deploy-site workflow (6c848dc, #164)
- allow sharp and workerd build scripts for wrangler in deploy-site CI (dd52283, #163)

### Contributors
- @jaredwray (15)

### Full List of Changes
- fix: allow sharp and workerd build scripts for wrangler by @jaredwray in #163
- fix: add Cloudflare account ID to deploy-site workflow by @jaredwray in #164
- Remove Node.js version requirement from features list by @jaredwray in #166
- ci: use npm provenance with OIDC for release workflow by @jaredwray in #165
- hookified - chore: migrate to corepack and pnpm 11 with defense-in-depth controls by @jaredwray in #167
- fix: remove once listeners/hooks when called with the original reference by @jaredwray in #168
- root - chore: upgrade code quality dependencies by @jaredwray in #169
- root - chore: upgrade TypeScript and build tooling by @jaredwray in #170
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #171

**Full diff:** https://github.com/jaredwray/hookified/compare/v3.0.0...v3.0.1

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds
- [x] `pnpm test:ci` passes locally (312/312, 100% coverage)
- [x] No uncommitted changes outside the version bump

## Post-merge
Merge the PR, then create a GitHub Release at tag `v3.0.1` — the `release.yaml` workflow publishes to npm (with OIDC provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQwfjdg2q66uvismo4Npju

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQwfjdg2q66uvismo4Npju)_