### PR TITLE
release: v3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hookified",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Event Emitting and Middleware Hooks",
   "type": "module",
   "main": "./dist/node/index.js",


### PR DESCRIPTION
## Release summary

Patch release covering the development dependency updates from #173. No changes to published code.

## hookified@3.0.2 — 2026-07-24

Development dependency updates only; no changes to published code.

### Internal
- update @biomejs/biome, vitest, @vitest/coverage-v8, docula, tsx, @types/node to latest (a3e53e4, #173)
- update @types/node to 26.1.1 (major) (c6b470b, #173)

### Contributors
- @jaredwray (2)

### Full List of Changes
- chore: update @biomejs/biome, vitest, @vitest/coverage-v8, docula, tsx to latest and @types/node to 26.1.1 (major) by @jaredwray in #173

**Full diff:** https://github.com/jaredwray/hookified/compare/v3.0.1...v3.0.2

## Verification

- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds
- [x] `pnpm test:ci` passes locally — 312 tests, 100% coverage
- [x] No uncommitted changes outside the version bump

The diff is one line: `package.json` `3.0.1` → `3.0.2`. No `CHANGELOG.md` in this project, so no changelog entry. The lockfile needed no refresh — there are no workspace cross-deps.

## Scope note

This release ships an artifact functionally identical to v3.0.1. `src/` and the build configuration are untouched, and the build toolchain is unchanged from v3.0.1 (`tsdown@0.22.2`, `typescript@6.0.3`, `rolldown@1.0.1`/`1.1.1`). Every package updated in #173 is a devDependency, and hookified publishes `dist` + `LICENSE` with zero runtime dependencies, so none of them reach a consumer's tree.

Cut deliberately after review — flagging it here so the version number isn't mistaken for a behavior change.

## Branch note

This would normally ship from `release/v3.0.2`. The environment pins this session to `claude/hookified-dependency-maintenance-89yp7q`, so the release cut is pushed there instead. The branch was restarted from the current `main` rather than stacked on the already-merged history from #173.

## Post-merge

Merge, then create a GitHub Release at tag `v3.0.2` — `release.yaml` triggers on `release: [released]` and publishes to npm with OIDC provenance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2WzqEjmzBExW4r3PCbiWo)_