### PR TITLE
release: v3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hookified",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Event Emitting and Middleware Hooks",
   "type": "module",
   "main": "./dist/node/index.js",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release summary

Patch release covering CI/publish hardening and development tooling upgrades since v3.0.2. No changes to published library code.

## hookified@3.0.3 — 2026-08-20

CI and publish hardening plus development tooling upgrades; no changes to published library code.

### Documentation
- add SECURITY.md and DEFENSE_IN_DEPTH.md (880b9b6, #175)
- record repository lockdown and completed manuals (1d463a6, #195)

### Internal
- add CODEOWNERS for high-risk paths (0752116, #184)
- bootstrap Aikido Safe Chain for cloud agents (2bc0f26, #185)
- drop first-party pnpm cooldown exclude (54a7f2a, #186)
- set pnpm trustPolicy to no-downgrade (af7bf6e, #187)
- pin all GitHub Actions via actions-up (8374a52, #188)
- wrap CI installs with Socket Firewall (2a5aeb5, #189)
- lint GitHub Actions workflows with zizmor (634187d, #190)
- disable persist-credentials on checkouts (1c27648, #191)
- disable setup-node cache on publish jobs (fae1dc3, #192)
- stage npm publishes from packed tarball (84a774d, #193)
- gate npm stage publish on Aikido scan-release (7a23b9e, #194)
- remove writr override (59b65d7, #196)
- upgrade code quality dependencies (bf7b54d, #197)
- upgrade TypeScript and build tooling (c04da8d, #198)
- upgrade pnpm (7dffb8a, #199)
- upgrade tinybench (21cdd8f, #200)

### Contributors
- @jaredwray (18)

### Full List of Changes
- hookified - chore: defense - add SECURITY.md and DEFENSE_IN_DEPTH.md by @jaredwray in #175
- hookified - chore: defense - add CODEOWNERS for high-risk paths by @jaredwray in #184
- hookified - chore: defense - bootstrap Aikido Safe Chain for cloud agents by @jaredwray in #185
- hookified - chore: defense - drop first-party pnpm cooldown exclude by @jaredwray in #186
- hookified - chore: defense - set pnpm trustPolicy to no-downgrade by @jaredwray in #187
- hookified - chore: defense - pin all GitHub Actions via actions-up by @jaredwray in #188
- hookified - chore: defense - wrap CI installs with Socket Firewall by @jaredwray in #189
- hookified - chore: defense - lint GitHub Actions workflows with zizmor by @jaredwray in #190
- hookified - chore: defense - disable persist-credentials on checkouts by @jaredwray in #191
- hookified - chore: defense - disable setup-node cache on publish jobs by @jaredwray in #192
- hookified - chore: defense - stage npm publishes from packed tarball by @jaredwray in #193
- hookified - chore: defense - gate npm stage publish on Aikido scan-release by @jaredwray in #194
- hookified - chore: defense - record repository lockdown and completed manuals by @jaredwray in #195
- hookified - chore: remove writr override by @jaredwray in #196
- hookified - chore: upgrade code quality dependencies by @jaredwray in #197
- hookified - chore: upgrade TypeScript and build tooling by @jaredwray in #198
- hookified - chore: upgrade pnpm by @jaredwray in #199
- hookified - chore: upgrade tinybench by @jaredwray in #200

**Full diff:** https://github.com/jaredwray/hookified/compare/v3.0.2...v3.0.3

## Verification

- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes locally — 312 tests, 100% coverage
- [x] No uncommitted changes outside the version bump

The diff is one line: `package.json` `3.0.2` → `3.0.3`. No `CHANGELOG.md` in this project, so no changelog entry. The lockfile needed no refresh — there are no workspace cross-deps.

## Scope note

This release ships an artifact functionally identical to v3.0.2. `src/` and `test/` are untouched. All 18 commits since the last tag are `chore:` (defense-in-depth, CI/publish hardening, and tooling upgrades). hookified publishes `dist` + `LICENSE` with zero runtime dependencies.

Cut deliberately so the next GitHub Release exercises the hardened `release.yaml` path (Aikido scan-release gate, packed-tarball staging, Socket Firewall, pinned actions).

## Post-merge

Merge, then create a GitHub Release at tag `v3.0.3` — `release.yaml` triggers on `release: [released]` and publishes to npm with OIDC provenance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17e38296-da0e-4f7e-9e1d-31240258afd8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17e38296-da0e-4f7e-9e1d-31240258afd8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

